### PR TITLE
Fix download links to be HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Inspired by a [Question on Software Recommendations](http://softwarerecs.stackex
 
 ## Releases
 
-[Huge JSON Viewer 0.4.12.19 Setup.exe.zip](http://wellisolutions.de/downloads/Huge-JSON-Viewer-0.4.12.19-Setup.exe_.zip) (13.8 MB)
+[Huge JSON Viewer 0.4.12.19 Setup.exe.zip](https://wellisolutions.de/downloads/Huge-JSON-Viewer-0.4.12.19-Setup.exe_.zip) (13.8 MB)
 
-[Huge JSON Viewer 0.4.12.19 Portable.zip](http://wellisolutions.de/downloads/Huge-JSON-Viewer-0.4.12.19-Portable.zip) (17.4 MB)
+[Huge JSON Viewer 0.4.12.19 Portable.zip](https://wellisolutions.de/downloads/Huge-JSON-Viewer-0.4.12.19-Portable.zip) (17.4 MB)
 
 ## Screenshots
 


### PR DESCRIPTION
Plain HTTP links give "Mixed Content" warning in Chrome 89 and don't download:

> Mixed Content: The site at 'https://github.com/' was loaded over a secure connection, but the file at 'https://wellisolutions.de/downloads/Huge-JSON-Viewer-0.4.12.19-Setup.exe_.zip' was redirected through an insecure connection. This file should be served over HTTPS. This download has been blocked. See https://blog.chromium.org/2020/02/protecting-users-from-insecure.html for more details.